### PR TITLE
Enable Qwik dev server to use Cloudflare bindings

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -37,7 +37,7 @@ const ignores = [
   "**/*.spec.tsx",
   "**/*.spec.ts",
   "**/.netlify",
-  "**/.wrangler",
+  "**/.wrangler/**",
   "**/pnpm-lock.yaml",
   "**/package-lock.json",
   "**/yarn.lock",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build.types": "tsc --incremental --noEmit",
     "cf-typegen": "wrangler types",
     "check": "bun run cf-typegen && bun run fmt.check && bun run lint && bun run lint:css && bun run lint:sql && bun run build.types",
-    "ci": "bun run check",
+    "ci": "bun run cf-typegen && bun run check",
     "deploy": "bun run build && bun run ./assetsignore.ts && wrangler deploy",
     "dev": "vite --mode ssr",
     "dev.debug": "node --inspect-brk ./node_modules/vite/bin/vite.js --mode ssr --force",

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -1,0 +1,17 @@
+type EnvGetter = {
+  get(key: string): unknown;
+};
+
+type PlatformWithEnv = {
+  env?: Record<string, unknown>;
+};
+
+export type BindingEvent = {
+  env: EnvGetter;
+  platform?: unknown;
+};
+
+export function getBinding<T>(event: BindingEvent, key: string): T | undefined {
+  const platformEnv = (event.platform as PlatformWithEnv | undefined)?.env;
+  return (platformEnv?.[key] ?? event.env.get(key)) as T | undefined;
+}

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -1,17 +1,19 @@
-type EnvGetter = {
-  get(key: string): unknown;
-};
+import type { RequestEventBase } from '@builder.io/qwik-city';
+
+type EnvGetter = RequestEventBase['env'];
 
 type PlatformWithEnv = {
   env?: Record<string, unknown>;
 };
 
-export type BindingEvent = {
-  env: EnvGetter;
-  platform?: unknown;
-};
+export type BindingEvent = Pick<RequestEventBase, 'env' | 'platform'>;
 
-export function getBinding<T>(event: BindingEvent, key: string): T | undefined {
+export function getBinding<K extends Parameters<EnvGetter['get']>[0]>(
+  event: BindingEvent,
+  key: K
+): ReturnType<EnvGetter['get']> | undefined {
   const platformEnv = (event.platform as PlatformWithEnv | undefined)?.env;
-  return (platformEnv?.[key] ?? event.env.get(key)) as T | undefined;
+  return (platformEnv?.[key] ?? event.env.get(key)) as
+    | ReturnType<EnvGetter['get']>
+    | undefined;
 }

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -1,19 +1,12 @@
-import type { RequestEventBase } from '@builder.io/qwik-city';
-
-type EnvGetter = RequestEventBase['env'];
+import type { RequestEventBase } from "@qwik.dev/router/middleware/request-handler";
 
 type PlatformWithEnv = {
   env?: Record<string, unknown>;
 };
 
-export type BindingEvent = Pick<RequestEventBase, 'env' | 'platform'>;
+export type BindingEvent = Pick<RequestEventBase<PlatformWithEnv>, "env"> &
+  Partial<Pick<RequestEventBase<PlatformWithEnv>, "platform">>;
 
-export function getBinding<K extends Parameters<EnvGetter['get']>[0]>(
-  event: BindingEvent,
-  key: K
-): ReturnType<EnvGetter['get']> | undefined {
-  const platformEnv = (event.platform as PlatformWithEnv | undefined)?.env;
-  return (platformEnv?.[key] ?? event.env.get(key)) as
-    | ReturnType<EnvGetter['get']>
-    | undefined;
+export function getBinding<T>(event: BindingEvent, key: string): T | undefined {
+  return (event.platform?.env?.[key] ?? event.env.get(key)) as T | undefined;
 }

--- a/src/routes/api/comments/[...id]/index.ts
+++ b/src/routes/api/comments/[...id]/index.ts
@@ -1,16 +1,17 @@
 import { RequestHandler } from "@qwik.dev/router";
 import * as v from "valibot";
+import { getBinding } from "~/lib/cloudflare";
 import { CommentSchema } from "~/lib/comments";
 import { logServerError } from "~/lib/server-log";
 
-export const onGet: RequestHandler = async ({ request, env, json }) => {
+export const onGet: RequestHandler = async (event) => {
+  const { request, json } = event;
   let postId: string | undefined;
   try {
     const url = new URL(request.url);
     postId = url.pathname.match(/^\/api\/comments\/(.+)$/)![1];
 
-    const result = await env
-      .get("DB")!
+    const result = await getBinding<D1Database>(event, "DB")!
       .prepare(
         "SELECT post_id, id, created_at, name, content FROM comments WHERE post_id = ? ORDER BY created_at DESC",
       )

--- a/src/routes/api/like/[...id]/index.ts
+++ b/src/routes/api/like/[...id]/index.ts
@@ -1,11 +1,12 @@
 import { RequestHandler } from "@qwik.dev/router";
+import { getBinding } from "~/lib/cloudflare";
 
-export const onPost: RequestHandler = async ({ request, env, json }) => {
+export const onPost: RequestHandler = async (event) => {
+  const { request, json } = event;
   try {
     const url = new URL(request.url);
     const id = url.pathname.match(/^\/api\/like\/(.+)$/)![1];
-    const row = await env
-      .get("DB")!
+    const row = await getBinding<D1Database>(event, "DB")!
       .prepare(
         `
           INSERT INTO likes (post_id, count)

--- a/src/routes/post/[...id]/index.tsx
+++ b/src/routes/post/[...id]/index.tsx
@@ -15,16 +15,18 @@ import * as postsSchema from "~/generated/posts/posts-valibot";
 import { Footnotes, Markdown } from "~/components/markdown";
 import { CommentSection } from "~/components/comments";
 import { CommentPostSchema, CommentSchema, type Comment } from "~/lib/comments";
+import { getBinding } from "~/lib/cloudflare";
 import { logServerError } from "~/lib/server-log";
 import { verifyTurnstileToken } from "~/lib/turnstile";
 
-export const usePost = routeLoader$(async ({ params, status, env }) => {
+export const usePost = routeLoader$(async (event) => {
+  const { params, status } = event;
   try {
-    console.log(env.get("DB"), env.get("KV"));
+    const db = getBinding<D1Database>(event, "DB");
+    const kv = getBinding<KVNamespace>(event, "KV");
     const [body, commentsResult] = await Promise.all([
-      env.get("KV")!.get(params.id, { type: "json" }),
-      env
-        .get("DB")!
+      kv!.get(params.id, { type: "json" }),
+      db!
         .prepare(
           "SELECT post_id, id, created_at, name, content FROM comments WHERE post_id = ? ORDER BY created_at DESC",
         )
@@ -35,7 +37,8 @@ export const usePost = routeLoader$(async ({ params, status, env }) => {
 
     const comments = v.parse(v.array(CommentSchema), commentsResult.results);
 
-    const turnstileSiteKey = env.get("TURNSTILE_SITE_KEY") || "";
+    const turnstileSiteKey =
+      getBinding<string>(event, "TURNSTILE_SITE_KEY") || "";
 
     return {
       body: v.parse(postsSchema.bodyDocument, body),
@@ -50,8 +53,9 @@ export const usePost = routeLoader$(async ({ params, status, env }) => {
 });
 
 export const useSubmitComment = routeAction$(
-  async ({ name, content, turnstileToken }, { env, fail, params }) => {
-    const secretKey = env.get("TURNSTILE_SECRET_KEY");
+  async ({ name, content, turnstileToken }, event) => {
+    const { fail, params } = event;
+    const secretKey = getBinding<string>(event, "TURNSTILE_SECRET_KEY");
     if (!secretKey) {
       return fail(500, { message: "Turnstile not configured" });
     }
@@ -64,8 +68,7 @@ export const useSubmitComment = routeAction$(
     const id = crypto.randomUUID();
     const createdAt = new Date().toISOString();
 
-    await env
-      .get("DB")!
+    await getBinding<D1Database>(event, "DB")!
       .prepare(
         "INSERT INTO comments (post_id, id, created_at, name, content) VALUES (?, ?, ?, ?, ?)",
       )
@@ -129,8 +132,8 @@ export default component$(() => {
   }
 });
 
-export const onStaticGenerate: StaticGenerateHandler = async ({ env }) => {
-  const d1 = env.get("DB");
+export const onStaticGenerate: StaticGenerateHandler = async (event) => {
+  const d1 = getBinding<D1Database>(event, "DB");
   const schema = v.nullish(
     v.array(
       v.object({

--- a/src/routes/post/page/[page]/index.tsx
+++ b/src/routes/post/page/[page]/index.tsx
@@ -9,12 +9,14 @@ import {
   paginate,
   toPostSummary,
 } from "~/lib/posts";
+import { getBinding } from "~/lib/cloudflare";
 import { logServerError } from "~/lib/server-log";
 
-export const usePostsPages = routeLoader$(async ({ params, status, env }) => {
+export const usePostsPages = routeLoader$(async (event) => {
+  const { params, status } = event;
   try {
     const current = parseInt(params.page, 10);
-    const d1 = env.get("DB");
+    const d1 = getBinding<D1Database>(event, "DB");
     const q1 = `
       SELECT posts.*, json_group_array(post_tags.tag) AS tags
       FROM posts LEFT JOIN post_tags ON posts.id = post_tags.post_id
@@ -62,8 +64,8 @@ export const usePostsPages = routeLoader$(async ({ params, status, env }) => {
   }
 });
 
-export const onStaticGenerate: StaticGenerateHandler = async ({ env }) => {
-  const d1 = env.get("DB");
+export const onStaticGenerate: StaticGenerateHandler = async (event) => {
+  const d1 = getBinding<D1Database>(event, "DB");
   if (d1) {
     const s = v.tuple([v.object({ count: v.number() })]);
     const [count] = v.parse(

--- a/src/routes/post/tag/[tag]/[page]/index.tsx
+++ b/src/routes/post/tag/[tag]/[page]/index.tsx
@@ -11,12 +11,14 @@ import {
   paginate,
   toPostSummary,
 } from "~/lib/posts";
+import { getBinding } from "~/lib/cloudflare";
 import { logServerError } from "~/lib/server-log";
 
-export const usePostsPages = routeLoader$(async ({ params, status, env }) => {
+export const usePostsPages = routeLoader$(async (event) => {
+  const { params, status } = event;
   try {
     const index = parseInt(params.page, 10);
-    const d1 = env.get("DB");
+    const d1 = getBinding<D1Database>(event, "DB");
     const meta_q = `
       SELECT posts.*, json_group_array(post_tags.tag) AS tags
       FROM post_tags AS tag_filter
@@ -77,7 +79,7 @@ export const usePostsPages = routeLoader$(async ({ params, status, env }) => {
   }
 });
 
-export const onStaticGenerate: StaticGenerateHandler = async ({ env }) => {
+export const onStaticGenerate: StaticGenerateHandler = async (event) => {
   const q = `
     SELECT COUNT(posts) AS count, tag
     FROM post_tags
@@ -85,7 +87,7 @@ export const onStaticGenerate: StaticGenerateHandler = async ({ env }) => {
     WHERE posts.publish
     GROUP BY post_tags.tag;
   `;
-  const d1 = env.get("DB");
+  const d1 = getBinding<D1Database>(event, "DB");
   if (d1 === undefined) {
     return { params: [] };
   }

--- a/src/routes/rss.xml/index.ts
+++ b/src/routes/rss.xml/index.ts
@@ -1,6 +1,7 @@
 import { type RequestHandler } from "@qwik.dev/router";
 import { XMLBuilder } from "fast-xml-parser";
 import * as v from "valibot";
+import { getBinding } from "~/lib/cloudflare";
 import { postWithTagsSchema } from "~/lib/posts";
 
 interface RssItem {
@@ -49,8 +50,9 @@ function genRss(rss: RssProps): string {
   return builder.build(obj);
 }
 
-export const onGet: RequestHandler = async ({ request, send, env }) => {
-  const d1 = env.get("DB");
+export const onGet: RequestHandler = async (event) => {
+  const { request, send } = event;
+  const d1 = getBinding<D1Database>(event, "DB");
   const url = new URL(request.url);
   const base = {
     title: "namachan10777.dev",

--- a/src/routes/rss.xml/index.ts
+++ b/src/routes/rss.xml/index.ts
@@ -62,7 +62,7 @@ export const onGet: RequestHandler = async (event) => {
     items: [],
   };
   if (d1 === undefined) {
-    genRss(base);
+    send(200, genRss(base));
     return;
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@
  * When building, the adapter config is used which loads this file and extends it.
  */
 import { defineConfig, type UserConfig } from "vite";
+import { getPlatformProxy } from "wrangler";
 import { qwikVite } from "@qwik.dev/core/optimizer";
 import { qwikRouter } from "@qwik.dev/router/vite";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -20,11 +21,14 @@ errorOnDuplicatesPkgDeps(devDependencies, dependencies);
  */
 
 
-export default defineConfig((): UserConfig => {
+export default defineConfig(async ({ command }): Promise<UserConfig> => {
+  const platform =
+    command === "serve" ? await getPlatformProxy<Env>() : undefined;
+
   return {
     plugins: [
       tsconfigPaths(),
-      qwikRouter(),
+      qwikRouter(platform ? { platform } : undefined),
       qwikVite({ experimental: ["valibot"] }),
       Icons({ compiler: "qwik" }),
     ],


### PR DESCRIPTION
## Summary
- wire Qwik's Vite dev server to Wrangler getPlatformProxy so route handlers can access Cloudflare bindings during local dev
- add a shared binding helper that supports both production env.get() and dev platform.env
- ignore Wrangler temporary files in ESLint

## Verification
- bun run build.types
- bun run lint
- bun run build